### PR TITLE
Update app-fqdn-rules.tf

### DIFF
--- a/app-fqdn-rules.tf
+++ b/app-fqdn-rules.tf
@@ -4,6 +4,7 @@ locals {
     tcp = {
       "*.aviatrix.com" = "443"
       "aviatrix.com"   = "80"
+       "*.ubuntu.com"   = "80"
     }
     udp = {
       "dns.google.com" = "53"


### PR DESCRIPTION
## Description

add ubuntu.com:80  allowed in  app-fqdn-rules.tf file as in lab 3 at https://aviatrix.teachable.com/courses/1598723/lectures/36562350
